### PR TITLE
action: Use setup-ninja instead of setup-cpp and use absoulte paths for cmake invocation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -48,11 +48,13 @@ runs:
         path: ${{ runner.tool_cache }}/jakt
         key: jakt-${{ runner.os }}-${{ runner.arch }}-${{ steps.check_cache.outputs.jakt-hash }}
         restore-keys: jakt-${{ runner.os }}-${{ runner.arch }}
-    - uses: aminya/setup-cpp@v1
+    - name: Setup Ninja
+      uses: ashutoshvarma/setup-ninja@master
       with:
-        llvm: 14.0.0
-        cmake: ${{ steps.check_cache.outputs.cache_hit != true }}
-        ninja: ${{ steps.check_cache.outputs.cache_hit != true }}
+        # ninja version to download. Default: 1.10.0
+        version: 1.10.0
+    - run: ninja --version
+      shell: bash
     - run: node lib/jakt/main.js
       if: ${{ steps.check_cache.outputs.cache_hit != true }}
       id: build_jakt

--- a/lib/jakt/check_cache.js
+++ b/lib/jakt/check_cache.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];

--- a/lib/jakt/main.js
+++ b/lib/jakt/main.js
@@ -1,11 +1,7 @@
 "use strict";
 var __createBinding = (this && this.__createBinding) || (Object.create ? (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
-    var desc = Object.getOwnPropertyDescriptor(m, k);
-    if (!desc || ("get" in desc ? !m.__esModule : desc.writable || desc.configurable)) {
-      desc = { enumerable: true, get: function() { return m[k]; } };
-    }
-    Object.defineProperty(o, k2, desc);
+    Object.defineProperty(o, k2, { enumerable: true, get: function() { return m[k]; } });
 }) : (function(o, m, k, k2) {
     if (k2 === undefined) k2 = k;
     o[k2] = m[k];
@@ -126,7 +122,7 @@ function run() {
                     }
                     core.addPath(cmakeBinPath);
                     _d.label = 8;
-                case 8: return [4 /*yield*/, runCommand(buildPath, "cmake", "-DCMAKE_CXX_COMPILER=clang++", "-DCMAKE_INSTALL_PREFIX=".concat(jaktPath), "-GNinja", "-S", "..")];
+                case 8: return [4 /*yield*/, runCommand(process_1["default"].env["GITHUB_WORKSPACE"], "cmake", "-DCMAKE_CXX_COMPILER=clang++", "-DCMAKE_INSTALL_PREFIX=".concat(jaktPath), "-GNinja", "-S", "".concat(extractedPath), "-B", "".concat(buildPath))];
                 case 9:
                     _d.sent();
                     return [4 /*yield*/, runCommand(buildPath, "cmake", "--build", ".")];

--- a/src/jakt/main.ts
+++ b/src/jakt/main.ts
@@ -56,13 +56,15 @@ async function run() {
     }
 
     await runCommand(
-        buildPath,
+        process.env["GITHUB_WORKSPACE"],
         "cmake",
         "-DCMAKE_CXX_COMPILER=clang++",
         `-DCMAKE_INSTALL_PREFIX=${jaktPath}`,
         "-GNinja",
         "-S",
-        ".."
+        `${extractedPath}`,
+        "-B",
+        `${buildPath}`
     );
     await runCommand(buildPath, "cmake", "--build", ".");
     await runCommand(buildPath, "cmake", "--install", ".");
@@ -93,7 +95,7 @@ function cmakePrefixPath(jaktPath: string): string {
     return `${appendedPath}${separator}${existingPath}`;
 }
 
-async function runCommand(cwd: string, command: string, ...args: string[]): Promise<void> {
+async function runCommand(cwd: string | undefined, command: string, ...args: string[]): Promise<void> {
     return new Promise((res, rej) => {
         try {
             let process = child_process.spawn(command, args, {


### PR DESCRIPTION
setup-cpp was giving compiler binaries in the cached tool path that could not properly find native host toolchain headers on Ubuntu and macOS. 

Change to rely on the pre-installed compilers rather than trying to get llvm using the third-party action, and use setup-ninja to make sure we have ninja installed. Because the setup-ninja action doesn't use an absolute path for its `core.addPath()` call (whyyyyyyy) we have to make sure to root the initial cmake configuration in $GITHUB_WORKSPACE rather than `buildPath`.

Succesful run using this: https://github.com/jntrnr/jaktnesmonster/actions/runs/3505500353/jobs/5871847368